### PR TITLE
Adapt block_size to requiered value to download and discard game media

### DIFF
--- a/src/main/java/de/fabianonline/telegram_backup/DownloadManager.java
+++ b/src/main/java/de/fabianonline/telegram_backup/DownloadManager.java
@@ -473,7 +473,7 @@ public class DownloadManager {
 			boolean try_again;
 			do {
 				try_again = false;
-				int block_size = 1073741824;
+				int block_size = 1048576;
 				logger.trace("offset: {} block_size: {} size: {}", offset, block_size, size);
 				TLRequestUploadGetFile req = new TLRequestUploadGetFile(loc, offset, block_size);
 				try {

--- a/src/main/java/de/fabianonline/telegram_backup/mediafilemanager/FileManagerFactory.java
+++ b/src/main/java/de/fabianonline/telegram_backup/mediafilemanager/FileManagerFactory.java
@@ -72,6 +72,8 @@ public class FileManagerFactory {
 			return new UnsupportedFileManager(p, m, u, c, "contact");
 		} else if (media instanceof TLMessageMediaVenue) {
 			return new UnsupportedFileManager(p, m, u, c, "venue");
+		} else if (media instanceof TLMessageMediaGame) {
+			return new UnsupportedFileManager(p, m, u, c, "game");
 		} else {
 			AbstractMediaFileManager.throwUnexpectedObjectError(media);
 		}


### PR DESCRIPTION
While downloading it was returning a 400 value but without showing any message. After a bit of debugging I realised it was returning a 400 LIMIT_INVALID. Setting the block_size to 1KB makes it work.
https://core.telegram.org/api/files